### PR TITLE
Datastore Delete Fixes

### DIFF
--- a/ckanext/dsaudit/actions.py
+++ b/ckanext/dsaudit/actions.py
@@ -122,7 +122,8 @@ def datastore_upsert(original_action, context, data_dict):
     return rval
 
 
-def _datastore_delete(original_action, context, data_dict):
+@chained_action
+def datastore_delete(original_action, context, data_dict):
     res = context['model'].Resource.get(data_dict.get('resource_id'))
     if not res or res.url_type not in h.datastore_rw_resource_url_types():
         return original_action(context, data_dict)
@@ -161,16 +162,6 @@ def _datastore_delete(original_action, context, data_dict):
         'data': activity_data,
     })
     return rval
-
-
-@chained_action
-def datastore_delete(original_action, context, data_dict):
-    return _datastore_delete(original_action, context, data_dict)
-
-
-@chained_action
-def datastore_records_delete(original_action, context, data_dict):
-    return _datastore_delete(original_action, context, data_dict)
 
 
 def dsaudit_create_activity_schema():

--- a/ckanext/dsaudit/plugins.py
+++ b/ckanext/dsaudit/plugins.py
@@ -23,7 +23,6 @@ class DSAuditPlugin(p.SingletonPlugin, DefaultTranslation):
             'datastore_create': actions.datastore_create,
             'datastore_upsert': actions.datastore_upsert,
             'datastore_delete': actions.datastore_delete,
-            'datastore_records_delete': actions.datastore_records_delete,
         }
 
     def get_helpers(self):

--- a/ckanext/dsaudit/plugins.py
+++ b/ckanext/dsaudit/plugins.py
@@ -23,6 +23,7 @@ class DSAuditPlugin(p.SingletonPlugin, DefaultTranslation):
             'datastore_create': actions.datastore_create,
             'datastore_upsert': actions.datastore_upsert,
             'datastore_delete': actions.datastore_delete,
+            'datastore_records_delete': actions.datastore_records_delete,
         }
 
     def get_helpers(self):


### PR DESCRIPTION
fix(logic): datastore delete;

- Fixed error on non-existant filters in datastore delete.
- Added chained `datastore_records_delete`.